### PR TITLE
Add ContentHandler class and initialise SagemakerEndpoint LLM

### DIFF
--- a/backend/deploy_llm.py
+++ b/backend/deploy_llm.py
@@ -1,4 +1,8 @@
 from sagemaker.huggingface import HuggingFaceModel, get_huggingface_llm_image_uri
+from langchain.llms.sagemaker_endpoint import LLMContentHandler
+from langchain.llms import SagemakerEndpoint
+from typing import Dict
+import boto3
 import json
 
 def deploy_language_model(role):
@@ -28,3 +32,49 @@ def deploy_language_model(role):
     print(f'Language model deployed. Endpoint {endpoint_name}')
     print(f'Hub config:\n {hub}')
     return endpoint_name
+
+class ContentHandler(LLMContentHandler):
+
+    content_type = 'application/json'
+    accepts = 'application/json'
+
+    # Mistral-7B-Instruct requires <s>[INST] boundary tokens in input
+    def transform_input(self, prompt: str, model_kwargs: Dict) -> bytes:
+        input_string = json.dumps(
+            {
+                'inputs': f'<s>[INST] {prompt} [/INST]',
+                'parameters': {**model_kwargs}
+            }
+        )
+        return input_string.encode('utf-8')
+    
+    def transform_output(self, output: bytes) -> str:
+        response_json = json.loads(output.read().decode('utf-8'))
+        answer_split = response_json[0]['generated_text'].split('[/INST] ')
+        return answer_split[1]
+
+def build_sagemaker_llm_endpoint(role):
+    """
+    This function builds and returns a SagemakerEndpoint class.
+    """
+
+    model_kwargs = {
+        "max_new_tokens": 512,
+        "top_p": 0.3,
+        "temperature": 0.1,
+    }
+
+    # If the LLM is not already deployed, uncomment the following line:
+    # llm_endpoint_name = deploy_language_model(role)
+    # Will be updated to automatically check if it is deployed (i.e. checking if it exists in env or another method)
+    llm_endpoint_name = os.environ.get("LLM_ENDPOINT_NAME")
+    sagemaker_runtime = boto3.client("sagemaker-runtime")
+    content_handler = ContentHandler()
+    llm = SagemakerEndpoint(
+        endpoint_name=llm_endpoint_name,
+        model_kwargs=model_kwargs,
+        content_handler=content_handler,
+        client=sagemaker_runtime,
+    )
+
+    return llm


### PR DESCRIPTION
Additional content has been added to the `deploy_llm.py` file in this PR.

A `ContentHandler` class, which inherits from the Langchain [LLMContentHandler class](https://api.python.langchain.com/en/latest/llms/langchain_community.llms.sagemaker_endpoint.LLMContentHandler.html), has been created. This class defines input and output transformation functions to transform data going into and coming out of the deployed LLM. 

Since Mistral-7B-Instruct-v0.1 is being utilised currently, the `ContentHandler` class was bespokely created to work with that model. This model expects the first instruction to begin with a 'begin of sentence id' (`<s>`), as well as requiring opening and closing `[INST]` and `[/INST]` tags around the prompt. See https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1 for further information.

The function `build_sagemaker_llm_endpoint` has also been added, which constructs the [SagemakerEndpoint](https://python.langchain.com/docs/integrations/llms/sagemaker) class using the deployed LLM's name, the model keyword arguments, the custom content handler and the sagemaker runtime as parameters. The instance of the SagemakerEndpoint class is returned to be used in constructing the retrieval QA chain.