### PR TITLE
Pull out result and source_documents from RAG Chain invocation

### DIFF
--- a/backend/rag/lambda_handler.py
+++ b/backend/rag/lambda_handler.py
@@ -16,10 +16,19 @@ def lambda_handler(event, context):
             "body": json.dumps({"error": "Query parameter not found in request body"})
         }
     # Initialize and run the QA chain
-    response = chain.run({"query": query})
+    output = chain.run({"query": query})
+
+    result = output["result"]
+    source_documents = output["source_documents"]
 
     # Return the QA chain response
     return {
         "statusCode": 200,
-        "body": json.dumps(response)
+        "body": json.dumps({
+            "result": result,
+            "source_documents": source_documents
+        }),
+        "headers": {
+            "Content-Type": "application/json"
+        }
     }


### PR DESCRIPTION
The following error was being received with the AWS Lambda function:

```
 "errorMessage": "`run` not supported when there is not exactly one output key. Got ['result', 'source_documents'].",
```

The issue was due to the RetrievalQA chain having the `return_source_documents` property set to `True`, whereas, when `chain.run()` was called in `lambda_handler.py`, it expected only one response.

`lambda_handler.py` has been updated such that both the result and source documents are extracted and handled separately.