### PR TITLE
Use chain() instead of chain.run()

### DIFF
--- a/backend/rag/lambda_handler.py
+++ b/backend/rag/lambda_handler.py
@@ -16,7 +16,7 @@ def lambda_handler(event, context):
             "body": json.dumps({"error": "Query parameter not found in request body"})
         }
     # Initialize and run the QA chain
-    output = chain.run({"query": query})
+    output = chain({"query": query}, return_only_outputs=True)
 
     result = output["result"]
     source_documents = output["source_documents"]


### PR DESCRIPTION
This error:

```
"`run` not supported when there is not exactly one output key. Got ['result', 'source_documents'].",
```

was encoutered in AWS Lambda. To address this, `chain.run()` was replaced with `chain()`