### PR TITLE
Remove clashing params to enable serverless inference

### DIFF
--- a/backend/deployment/deploy_llm.py
+++ b/backend/deployment/deploy_llm.py
@@ -42,9 +42,6 @@ def deploy_language_model(role):
 
     # deploy model to SageMaker Inference
     predictor = huggingface_model.deploy(
-    	initial_instance_count=1,
-    	instance_type="ml.g5.2xlarge",
-    	container_startup_health_check_timeout=300,
       endpoint_name=endpoint_name,
       serverless_config=serverless_config,
       )


### PR DESCRIPTION
- Removed `initial_instance_count`, `instance_type` and `container_startup_health_check_timeout`, since they are not necessary when using serverless inference.
- These params were causing the endpoint to deployed as 'real-time'. 
- https://sagemaker.readthedocs.io/en/stable/frameworks/huggingface/sagemaker.huggingface.html
