### PR TITLE
Ensure question and chat history are passed to prompt template

### DIFF
--- a/backend/rag/retrieval_qa_chain.py
+++ b/backend/rag/retrieval_qa_chain.py
@@ -141,6 +141,8 @@ def create_qa_chain(table_name, session_id, conversation_id):
 
     chain = ({
         "context": itemgetter("question") | retriever | format_docs,
+        "question": itemgetter("question")
+        "chat_history": itemgetter("chat_history")
     } | RunnableParallel({
         "answer": prompt | llm,
         "context": itemgetter("context")


### PR DESCRIPTION
- Prompt template requires the keys `chat_history`, `question`, and `context`, so `itemgetter` is used to fetch these variables before piping them to the runnableparallel to generate a response