### PR TITLE
Ensure user input placeholder is consistently called 'input' to work …

### DIFF
--- a/backend/rag/lambda_handler.py
+++ b/backend/rag/lambda_handler.py
@@ -50,7 +50,7 @@ def lambda_handler(event, context):
 
     # Initialize and run the QA chain
     output = chain.invoke(
-        {"question": query},
+        {"input": query},
         config={"configurable": {"session_id": user_id}},
     )
     logger.info(f"Output: {output}")

--- a/backend/rag/retrieval_qa_chain.py
+++ b/backend/rag/retrieval_qa_chain.py
@@ -54,7 +54,7 @@ def create_prompt_template():
         [
             ("system", prompt_template),
             MessagesPlaceholder(variable_name="chat_history"),
-            ("human", "{question}"),
+            ("human", "{input}"),
         ]
     )
 
@@ -116,7 +116,7 @@ def create_qa_chain(table_name, session_id, conversation_id):
         [
             ("system", contextualize_question_prompt),
             MessagesPlaceholder(variable_name="chat_history"),
-            ("human", "{question}")
+            ("human", "{input}")
         ]
     )
     context_aware_retriever = create_history_aware_retriever(
@@ -159,7 +159,7 @@ def create_qa_chain(table_name, session_id, conversation_id):
             session_id=session_id,
             key=dynamo_db_key
         ),
-        input_messages_key="question",
+        input_messages_key="input",
         history_messages_key="chat_history",
         output_messages_key="answer"
     )


### PR DESCRIPTION
…with langchain classes

- Replace input placeholders in prompt templates and in the `chain.invoke()` method to all be `{input}`. This is done to ensure consistency across code and to ensure langchain classes receive the expected inputs