### PR TITLE
Allow frontend service to call aws cognito

### DIFF
--- a/infra/frontend/frontend_stack.py
+++ b/infra/frontend/frontend_stack.py
@@ -82,6 +82,7 @@ class FrontendStack(Stack):
             inline_policies={
                 "ECRAndSageMakerAccess": iam.PolicyDocument(
                     statements=[
+                        # ECR image pull permissions
                         iam.PolicyStatement(
                             actions=[
                                 "ecr:GetAuthorizationToken",
@@ -92,10 +93,15 @@ class FrontendStack(Stack):
                             ],
                             resources=["*"]
                         ),
+                        # SageMaker endpoint permissions
                         iam.PolicyStatement(
                             actions=["sagemaker:DescribeEndpoint"],
                             resources=["arn:aws:sagemaker:eu-west-1:349382198749:endpoint/huggingface-rag-llm-endpoint"],
                         ),
+                        # Cognito permissions
+                        iam.ManagedPolicy.from_aws_managed_policy_name(
+                            "AmazonCognitoPowerUser"
+                        )
                     ]
                 )
             },


### PR DESCRIPTION
- Add the `AmazonCognitoPowerUser` [managed policy](https://docs.aws.amazon.com/cognito/latest/developerguide/security-iam-awsmanpol.html) with the [AWS CDK Managed Policy class](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_iam/ManagedPolicy.html)
- This was done to allow the cognito auth flows to be managed from the frontend server